### PR TITLE
Update to Terraform >1.0 and expand customization options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Added
 - Added `container_entrypoints`, `container_command`, and `container_command_args` to customize container launch
+- Added `nomad_job_extra`, `nomad_group_extra`, and `nomad_task_extra`, and `nomad_docker_config_extra` to customize job template
 - Added `use_static_port` to make the `container_port` be a static port
 - Added `use_connect` to make Consul Connect optional, default to `true` for backwards compatibility
 - Added `pg_isready_path` to customize the path to `pg_isready` health check script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.5.0]
 
+### BREAKING
+ - The `use_host_volume` flag is removed and now triggered by setting `nomad_host_volume`.
+   Previously, `nomad_host_volume` defaulted to `"persistence"`, but now defaults to `""`.
+
 ### Changed
 - Updated to work with Terraform >1.0
 - Fixed `consul_tags` rendering of multiple tags
@@ -16,6 +20,7 @@
 - Added `use_static_port` to make the `container_port` be a static port
 - Added `use_connect` to make Consul Connect optional, default to `true` for backwards compatibility
 - Added `pg_isready_path` to customize the path to `pg_isready` health check script
+- Added `nomad_csi_volume` and `nomad_csi_volume_extra` to support mounting CSI volumes (such as NFS!)
 
 ## [0.4.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.5.0]
+
+### Changed
+- Updated to work with Terraform >1.0
+- Fixed `consul_tags` rendering of multiple tags
+- Fixed `nomad_datacenters` rendering of multiple datacenters
+- `nomad_datacenters` now defaults to the Nomad default of `["*"]`
+- Port assignments are now done via the `network` stanza instead of `service` stanza
+- Less extraneous whitespace in the generated Nomad job file
+
+### Added
+- Added `container_entrypoints`, `container_command`, and `container_command_args` to customize container launch
+- Added `use_static_port` to make the `container_port` be a static port
+- Added `use_connect` to make Consul Connect optional, default to `true` for backwards compatibility
+
 ## [0.4.2]
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added `container_entrypoints`, `container_command`, and `container_command_args` to customize container launch
 - Added `use_static_port` to make the `container_port` be a static port
 - Added `use_connect` to make Consul Connect optional, default to `true` for backwards compatibility
+- Added `pg_isready_path` to customize the path to `pg_isready` health check script
 
 ## [0.4.2]
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ module "postgres" {
 |------|-------------|------|---------|:--------:|
 | nomad_datacenters | Nomad data centers | list(string) | ["*"] | no |
 | nomad_namespace | [Enterprise] Nomad namespace | string | "default" | no |
+| nomad_node | Nomad node to constrain with `node.unique.name` | string | "" | no |
 | nomad_host_volume | Nomad host volume name | string | "" | no |
 | nomad_csi_volume | Nomad CSI volume name to mount | string | "" | no |
 | nomad_csi_volume_extra | Extra config to inject in Nomad's CSI volume stanza | string | "" | no |

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ module "postgres" {
 | nomad_host_network | Nomad `network.port["psql"].host_network` | string | "" | no |
 | nomad_network_mode | Nomad `network.network_mode` | string | "" | no |
 | nomad_docker_network_mode | Postgres task Docker `config.network_mode` | string | "" | no |
+| update_health_check | Nomad `update.health_check` | string | "checks" | no |
 | service_tags | List of one or more tags to announce in Consul / Nomad, for service discovery purposes | list(string) | [""] | no |
 | service_name | Postgres service name | string | "postgres" | no |
 | container_image | Postgres docker image | string | "postgres:12-alpine" | no |

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ module "postgres" {
 | nomad_host_network | Nomad `network.port["psql"].host_network` | string | "" | no |
 | nomad_network_mode | Nomad `network.network_mode` | string | "" | no |
 | nomad_docker_network_mode | Postgres task Docker `config.network_mode` | string | "" | no |
-| consul_tags | List of one or more tags to announce in Consul, for service discovery purposes | list(string) | [""] | no |
+| service_tags | List of one or more tags to announce in Consul / Nomad, for service discovery purposes | list(string) | [""] | no |
 | service_name | Postgres service name | string | "postgres" | no |
 | container_image | Postgres docker image | string | "postgres:12-alpine" | no |
 | container_entrypoints | Docker driver entrypoint array | list(string) | no |

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ module "postgres" {
 | admin_user | Postgres admin username | string | "postgres" | no |
 | admin_password | Postgres admin password | string | "postgres" | no |
 | database | Postgres database name | string | "metastore" | no |
+| pg_isready_path | Path to `pg_isready` script for health checks" | string | "/usr/local/bin/pg_isready" | no |
 | container_environment_variables | Postgres container environement variables | list(string) | ["PGDATA=/var/lib/postgresql/data"] | no |
 | volume_destination | Postgres volume destination | string | "/var/lib/postgresql/data" | no |
 | use_host_volume | Use nomad host volume | bool | false | no |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ module "postgres" {
 | container_command | Docker driver command string | string | no |
 | container_command_args | Docker driver command args array | list(string) | no |
 | container_port | Postgres port | number | 5432 | no |
+| use_static_port | Switch to make container_port static | bool | false | no |
 | admin_user | Postgres admin username | string | "postgres" | no |
 | admin_password | Postgres admin password | string | "postgres" | no |
 | database | Postgres database name | string | "metastore" | no |

--- a/README.md
+++ b/README.md
@@ -106,8 +106,11 @@ module "postgres" {
 | nomad_host_volume | Nomad host volume name | string | "persistence" | no |
 | consul_tags | List of one or more tags to announce in Consul, for service discovery purposes | list(string) | [""] | no |
 | service_name | Postgres service name | string | "postgres" | no |
-| container_port | Postgres port | number | 5432 | no |
 | container_image | Postgres docker image | string | "postgres:12-alpine" | no |
+| container_entrypoints | Docker driver entrypoint array | list(string) | no |
+| container_command | Docker driver command string | string | no |
+| container_command_args | Docker driver command args array | list(string) | no |
+| container_port | Postgres port | number | 5432 | no |
 | admin_user | Postgres admin username | string | "postgres" | no |
 | admin_password | Postgres admin password | string | "postgres" | no |
 | database | Postgres database name | string | "metastore" | no |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can verify that Postgres is running by checking the connection. The followin
 make proxy
 ```
 
-Further, you can verify the connection by connecting with the psql CLI ([required software](#required-software)) using the command bellow.
+Further, you can verify the connection by connecting with the psql CLI ([required software](#required-software)) using the command below.
 You can find the `username` and `password` in the [Vault UI (localhost:8200)](http://localhost:8200/).
 ```sh
 psql "dbname=metastore host=127.0.0.1 user=<username> password=<password> port=5432 sslmode=disable"
@@ -84,6 +84,7 @@ module "postgres" {
   vault_secret                    = {
                                       use_vault_provider      = false,
                                       vault_kv_path           = "",
+                                      vault_kv_policy_name    = "",
                                       vault_kv_field_username = "",
                                       vault_kv_field_password = ""
                                     }
@@ -113,7 +114,8 @@ module "postgres" {
 | container_environment_variables | Postgres container environement variables | list(string) | ["PGDATA=/var/lib/postgresql/data"] | no |
 | volume_destination | Postgres volume destination | string | "/var/lib/postgresql/data" | no |
 | use_host_volume | Use nomad host volume | bool | false | no |
-| use_canary | Switch to use canary deployment for Postgres | bool | no |
+| use_canary | Switch to use canary deployment for Postgres | bool | true | no |
+| use_connect | Use Consul Connect | bool | true | no |
 | vault_secret.use_vault_provider | Set if want to access secrets from Vault | bool | true | no |
 | vault_secret.vault_kv_policy_name | Vault policy name to read secrets | string | "kv-secret" | no |
 | vault_secret.vault_kv_path | Path to the secret key in Vault | string | "secret/data/postgres" | no |
@@ -157,7 +159,7 @@ module "postgres" {
 ### Set credentials using Vault secrets
 By default `use_vault_provider` is set to `false`. 
 However, when testing using the box (e.g. `make dev`) the postgres username and password is randomly generated and put in `secret/postgres` inside Vault, from the [01_generate_secrets_vault.yml](dev/ansible/01_generate_secrets_vault.yml) playbook. 
-This is an independet process and will run regardless of the `vault_secret.use_vault_provider` is `false/true`. 
+This is an independent process and will run regardless of the `vault_secret.use_vault_provider` is `false/true`.
 
 If you want to use the automatically generated credentials in the box, you can do so by changing the `vault_secret` object as seen below:
 ```hcl-terraform

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ module "postgres" {
 | use_host_volume | Use nomad host volume | bool | false | no |
 | use_canary | Switch to use canary deployment for Postgres | bool | true | no |
 | use_connect | Use Consul Connect | bool | true | no |
-| vault_secret.use_vault_provider | Set if want to access secrets from Vault | bool | true | no |
+| vault_secret.use_vault_provider | Set if want to access secrets from Vault | bool | false | no |
 | vault_secret.vault_kv_policy_name | Vault policy name to read secrets | string | "kv-secret" | no |
 | vault_secret.vault_kv_path | Path to the secret key in Vault | string | "secret/data/postgres" | no |
 | vault_secret.vault_kv_field_username | Secret key name in Vault kv path | string | "username" | no |

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ module "postgres" {
 ## Inputs
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| nomad_datacenters | Nomad data centers | list(string) | ["dc1"] | no |
+| nomad_datacenters | Nomad data centers | list(string) | ["*"] | no |
 | nomad_namespace | [Enterprise] Nomad namespace | string | "default" | no |
 | nomad_host_volume | Nomad host volume name | string | "persistence" | no |
 | consul_tags | List of one or more tags to announce in Consul, for service discovery purposes | list(string) | [""] | no |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ module "postgres" {
   admin_password                  = "postgres"
   database                        = "metastore"
   volume_destination              = "/var/lib/postgresql/data"
-  use_host_volume                 = true
+  nomad_host_volume               = "/local/postgres"
   use_canary                      = false
   container_environment_variables = ["PGDATA=/var/lib/postgresql/data/"]
 }
@@ -103,7 +103,9 @@ module "postgres" {
 |------|-------------|------|---------|:--------:|
 | nomad_datacenters | Nomad data centers | list(string) | ["*"] | no |
 | nomad_namespace | [Enterprise] Nomad namespace | string | "default" | no |
-| nomad_host_volume | Nomad host volume name | string | "persistence" | no |
+| nomad_host_volume | Nomad host volume name | string | "" | no |
+| nomad_csi_volume | Nomad CSI volume name to mount | string | "" | no |
+| nomad_csi_volume_extra | Extra config to inject in Nomad's CSI volume stanza | string | "" | no |
 | nomad_job_extra | Extra config to inject in Nomad's job config stanza | string | "" | no |
 | nomad_group_extra | Extra config to inject in Nomad's group config stanza | string | "" | no |
 | nomad_task_extra | Extra config to inject in Nomad's task config stanza | string | "" | no |

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ module "postgres" {
 | nomad_datacenters | Nomad data centers | list(string) | ["*"] | no |
 | nomad_namespace | [Enterprise] Nomad namespace | string | "default" | no |
 | nomad_host_volume | Nomad host volume name | string | "persistence" | no |
+| nomad_job_extra | Extra config to inject in Nomad's job config stanza | string | "" | no |
+| nomad_group_extra | Extra config to inject in Nomad's group config stanza | string | "" | no |
+| nomad_task_extra | Extra config to inject in Nomad's task config stanza | string | "" | no |
+| nomad_docker_config_extra | Extra config to inject in Nomad's docker config stanza | string | "" | no |
 | consul_tags | List of one or more tags to announce in Consul, for service discovery purposes | list(string) | [""] | no |
 | service_name | Postgres service name | string | "postgres" | no |
 | container_image | Postgres docker image | string | "postgres:12-alpine" | no |

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ module "postgres" {
 | nomad_group_extra | Extra config to inject in Nomad's group config stanza | string | "" | no |
 | nomad_task_extra | Extra config to inject in Nomad's task config stanza | string | "" | no |
 | nomad_docker_config_extra | Extra config to inject in Nomad's docker config stanza | string | "" | no |
+| nomad_host_network | Nomad `network.port["psql"].host_network` | string | "" | no |
+| nomad_network_mode | Nomad `network.network_mode` | string | "" | no |
+| nomad_docker_network_mode | Postgres task Docker `config.network_mode` | string | "" | no |
 | consul_tags | List of one or more tags to announce in Consul, for service discovery purposes | list(string) | [""] | no |
 | service_name | Postgres service name | string | "postgres" | no |
 | container_image | Postgres docker image | string | "postgres:12-alpine" | no |
@@ -135,7 +138,8 @@ module "postgres" {
 | memory | Memory allocation for Postgres in MB | number | 428 | no |
 | cpu | CPU allocation for Postgres in MHz | number | 350 | no |
 | resource_proxy | Resource allocations for proxy | obj(number, number) |	{ <br> cpu = 200, <br> memory = 128 <br> } |	no |
- 	
+
+
 ## Outputs
 | Name | Description | Type |
 |------|-------------|------|

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -3,6 +3,13 @@ job "${service_name}" {
   datacenters = ${datacenters}
   namespace   = "${namespace}"
 
+%{ if "${nomad_node}" != "" }
+  constraint {
+    attribute = "$${node.unique.name}"
+    value     = "${nomad_node}"
+  }
+%{ endif }
+
   update {
     max_parallel      = 1
     health_check      = "${update_health_check}"

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -94,6 +94,9 @@ job "${service_name}" {
       %{~ if command_args != "[]" ~}
         args       = ${command_args}
       %{~ endif ~}
+      %{~ if docker_config_extra != "" ~}
+${docker_config_extra}
+      %{~ endif ~}
       }
 
       logs {
@@ -123,6 +126,12 @@ EOF
         memory = "${memory}"
         cpu    = "${cpu}"
       }
+    %{~ if task_extra != "" ~}
+${task_extra}
+    %{~ endif ~}
     }
+  %{~ if group_extra != "" ~}
+${group_extra}
+  %{~ endif ~}
   }
 }

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -42,7 +42,7 @@ job "${service_name}" {
       check {
         type      = "script"
         task      = "postgresql"
-        command   = "/usr/local/bin/pg_isready"
+        command   = "${pg_isready_path}"
       %{~ if use_vault_provider ~}
         args      = ["-U", "$POSTGRES_USER"]
       %{~ else ~}

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -19,12 +19,19 @@ job "${service_name}" {
 
   group "database" {
     network {
-      mode = "bridge"
-      %{~ if use_static_port ~}
-      port "psql" { static = ${port} }
-      %{~ else ~}
-      port "psql" { to = ${port} }
+      %{~ if nomad_network_mode != "" ~}
+      mode = "${nomad_network_mode}"
       %{~ endif ~}
+      port "psql" {
+      %{~ if nomad_host_network != "" ~}
+        host_network = "${nomad_host_network}"
+      %{~ endif ~}
+      %{~ if use_static_port ~}
+        static = ${port}
+      %{~ else ~}
+        to = ${port}
+      %{~ endif ~}
+      }
     }
 
   %{~ if nomad_host_volume != "" ~}
@@ -107,6 +114,9 @@ ${nomad_csi_volume_extra}
       %{~ endif ~}
       %{~ if command_args != "[]" ~}
         args       = ${command_args}
+      %{~ endif ~}
+      %{~ if nomad_docker_network_mode != "" ~}
+        network_mode = "${nomad_docker_network_mode}"
       %{~ endif ~}
       %{~ if docker_config_extra != "" ~}
 ${docker_config_extra}

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -20,6 +20,7 @@ job "${service_name}" {
   group "database" {
     network {
       mode = "bridge"
+      port "psql" { static = ${port} }
     }
 
   %{ if use_host_volume }
@@ -32,7 +33,7 @@ job "${service_name}" {
 
     service {
       name = "${service_name}"
-      port = "${port}"
+      port = "psql"
       tags = ["${consul_tags}"]
       check {
         type      = "script"

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -20,7 +20,11 @@ job "${service_name}" {
   group "database" {
     network {
       mode = "bridge"
+      %{~ if use_static_port ~}
       port "psql" { static = ${port} }
+      %{~ else ~}
+      port "psql" { to = ${port} }
+      %{~ endif ~}
     }
 
   %{ if use_host_volume }

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -43,11 +43,11 @@ job "${service_name}" {
         type      = "script"
         task      = "postgresql"
         command   = "/usr/local/bin/pg_isready"
-      %{ if use_vault_provider }
+      %{~ if use_vault_provider ~}
         args      = ["-U", "$POSTGRES_USER"]
-      %{ else }
+      %{~ else ~}
         args      = ["-U", "${username}"]
-      %{ endif }
+      %{~ endif ~}
         interval  = "30s"
         timeout   = "2s"
       }
@@ -69,25 +69,31 @@ job "${service_name}" {
 
     task "postgresql" {
       driver = "docker"
-    %{ if use_vault_provider }
+    %{~ if use_vault_provider ~}
       vault {
         policies = "${vault_kv_policy_name}"
       }
-    %{ endif }
+    %{~ endif ~}
 
-    %{ if use_host_volume }
+    %{~ if use_host_volume ~}
       volume_mount {
         volume      = "persistence"
         destination = "${volume_destination}"
         read_only   = false
       }
-    %{ endif }
+    %{~ endif ~}
 
       config {
         image      = "${image}"
-        %{ if entrypoints != "[]" }entrypoint = ${entrypoints}%{ endif }
-        %{ if command != "" }command    = "${command}"%{ endif }
-        %{ if command_args != "[]" }args       = ${command_args}%{ endif }
+      %{~ if entrypoints != "[]" ~}
+        entrypoint = ${entrypoints}
+      %{~ endif ~}
+      %{~ if command != "" ~}
+        command    = "${command}"
+      %{~ endif ~}
+      %{~ if command_args != "[]" ~}
+        args       = ${command_args}
+      %{~ endif ~}
       }
 
       logs {
@@ -105,10 +111,10 @@ job "${service_name}" {
 POSTGRES_USER="{{ .Data.data.${vault_kv_field_username} }}"
 POSTGRES_PASSWORD="{{ .Data.data.${vault_kv_field_password} }}"
 {{ end }}
-%{ else }
+%{ else ~}
 POSTGRES_USER="${username}"
 POSTGRES_PASSWORD="${password}"
-%{ endif }
+%{ endif ~}
 ${envs}
 EOF
       }

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -47,6 +47,7 @@ job "${service_name}" {
         timeout   = "2s"
       }
 
+      %{ if use_connect }
       connect {
         sidecar_service {
         }
@@ -58,6 +59,7 @@ job "${service_name}" {
           }
         }
       }
+      %{ endif }
     }
 
     task "postgresql" {

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -46,9 +46,11 @@ ${nomad_csi_volume_extra}
   %{~ endif ~}
 
     service {
+      provider = "${service_provider}"
       name = "${service_name}"
       port = "psql"
       tags = ${consul_tags}
+      %{~ if service_provider == "consul" ~}
       check {
         type      = "script"
         task      = "postgresql"
@@ -56,7 +58,7 @@ ${nomad_csi_volume_extra}
         interval  = "30s"
         timeout   = "2s"
       }
-
+      %{~ endif ~}
       %{ if use_connect }
       connect {
         sidecar_service {

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -34,7 +34,7 @@ job "${service_name}" {
     service {
       name = "${service_name}"
       port = "psql"
-      tags = ["${consul_tags}"]
+      tags = ${consul_tags}
       check {
         type      = "script"
         task      = "postgresql"

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -53,11 +53,6 @@ ${nomad_csi_volume_extra}
         type      = "script"
         task      = "postgresql"
         command   = "${pg_isready_path}"
-      %{~ if use_vault_provider ~}
-        args      = ["-U", "$POSTGRES_USER"]
-      %{~ else ~}
-        args      = ["-U", "${username}"]
-      %{~ endif ~}
         interval  = "30s"
         timeout   = "2s"
       }

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -5,7 +5,7 @@ job "${service_name}" {
 
   update {
     max_parallel      = 1
-    health_check      = "checks"
+    health_check      = "${update_health_check}"
     min_healthy_time  = "10s"
     healthy_deadline  = "10m"
     progress_deadline = "12m"

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -1,6 +1,6 @@
 job "${service_name}" {
   type        = "service"
-  datacenters = "${datacenters}"
+  datacenters = ${datacenters}
   namespace   = "${namespace}"
 
   update {

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -56,7 +56,7 @@ ${nomad_csi_volume_extra}
       provider = "${service_provider}"
       name = "${service_name}"
       port = "psql"
-      tags = ${consul_tags}
+      tags = ${service_tags}
       %{~ if service_provider == "consul" ~}
       check {
         type      = "script"

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -80,7 +80,10 @@ job "${service_name}" {
     %{ endif }
 
       config {
-        image = "${image}"
+        image      = "${image}"
+        %{ if entrypoints != "[]" }entrypoint = ${entrypoints}%{ endif }
+        %{ if command != "" }command    = "${command}"%{ endif }
+        %{ if command_args != "[]" }args       = ${command_args}%{ endif }
       }
 
       logs {

--- a/conf/nomad/postgres.hcl
+++ b/conf/nomad/postgres.hcl
@@ -27,13 +27,23 @@ job "${service_name}" {
       %{~ endif ~}
     }
 
-  %{ if use_host_volume }
+  %{~ if nomad_host_volume != "" ~}
     volume "persistence" {
       type      = "host"
       source    = "${nomad_host_volume}"
       read_only = false
     }
-  %{ endif }
+  %{~ endif }
+  %{~ if nomad_csi_volume != "" && nomad_host_volume == "" ~}
+    volume "persistence" {
+      type      = "csi"
+      source    = "${nomad_csi_volume}"
+      read_only = false
+    %{~ if nomad_csi_volume_extra != "" ~}
+${nomad_csi_volume_extra}
+    %{~ endif ~}
+    }
+  %{~ endif ~}
 
     service {
       name = "${service_name}"
@@ -75,13 +85,20 @@ job "${service_name}" {
       }
     %{~ endif ~}
 
-    %{~ if use_host_volume ~}
+    %{~ if nomad_host_volume != "" ~}
       volume_mount {
         volume      = "persistence"
         destination = "${volume_destination}"
         read_only   = false
       }
     %{~ endif ~}
+    %{~ if nomad_csi_volume != "" && nomad_host_volume == "" ~}
+      volume_mount {
+        volume      = "persistence"
+        destination = "${volume_destination}"
+        read_only   = false
+      }
+    %{ endif ~}
 
       config {
         image      = "${image}"

--- a/example/postgres_standalone/main.tf
+++ b/example/postgres_standalone/main.tf
@@ -7,7 +7,7 @@ module "postgres" {
   nomad_host_volume = "persistence"
 
   # consul
-  consul_tags                     = ["postgres"]
+  service_tags                     = ["postgres"]
 
   # postgres
   service_name                    = "postgres"

--- a/example/postgres_standalone/main.tf
+++ b/example/postgres_standalone/main.tf
@@ -22,7 +22,7 @@ module "postgres" {
                                     }
   database                        = "metastore"
   volume_destination              = "/var/lib/postgresql/data"
-  use_host_volume                 = true
+  nomad_host_volume               = "/host/volume/postgres"
   use_canary                      = true
   container_environment_variables = ["PGDATA=/var/lib/postgresql/data/"]
 }

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@ resource "nomad_job" "nomad_job_postgres" {
     memory_proxy            = var.resource_proxy.memory
     datacenters             = jsonencode(var.nomad_datacenters)
     namespace               = var.nomad_namespace
+    nomad_node              = var.nomad_node
     service_tags            = jsonencode(var.service_tags)
     update_health_check     = var.update_health_check
     image                   = var.container_image

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,4 @@
 locals {
-  datacenters = join(",", var.nomad_datacenters)
   postgres_env_vars = join("\n",
     concat([
       "POSTGRES_DB=${var.database}"
@@ -12,7 +11,7 @@ resource "nomad_job" "nomad_job_postgres" {
     service_name            = var.service_name
     cpu_proxy               = var.resource_proxy.cpu
     memory_proxy            = var.resource_proxy.memory
-    datacenters             = local.datacenters
+    datacenters             = jsonencode(var.nomad_datacenters)
     namespace               = var.nomad_namespace
     consul_tags             = jsonencode(var.consul_tags)
     image                   = var.container_image

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,10 @@ resource "nomad_job" "nomad_job_postgres" {
     command                 = var.container_command
     command_args            = jsonencode(var.container_command_args)
     port                    = var.container_port
+    job_extra               = var.nomad_job_extra
+    group_extra             = var.nomad_group_extra
+    task_extra              = var.nomad_task_extra
+    docker_config_extra     = var.nomad_docker_config_extra
     use_static_port         = var.use_static_port
     username                = var.admin_user
     password                = var.admin_password

--- a/main.tf
+++ b/main.tf
@@ -7,9 +7,8 @@ locals {
   )
 }
 
-data "template_file" "template_nomad_job_postgres" {
-  template = file("${path.module}/conf/nomad/postgres.hcl")
-  vars = {
+resource "nomad_job" "nomad_job_postgres" {
+  jobspec = templatefile("${path.module}/conf/nomad/postgres.hcl", {
     service_name            = var.service_name
     cpu_proxy               = var.resource_proxy.cpu
     memory_proxy            = var.resource_proxy.memory
@@ -30,13 +29,10 @@ data "template_file" "template_nomad_job_postgres" {
     volume_destination      = var.volume_destination
     use_host_volume         = var.use_host_volume
     use_canary              = var.use_canary
+    use_connect             = var.use_connect
     memory                  = var.memory
     cpu                     = var.cpu
     envs                    = local.postgres_env_vars
-  }
-}
-
-resource "nomad_job" "nomad_job_postgres" {
-  jobspec = data.template_file.template_nomad_job_postgres.rendered
-  detach  = false
+  })
+  detach = false
 }

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ resource "nomad_job" "nomad_job_postgres" {
     command                 = var.container_command
     command_args            = jsonencode(var.container_command_args)
     port                    = var.container_port
+    use_static_port         = var.use_static_port
     username                = var.admin_user
     password                = var.admin_password
     use_vault_provider      = var.vault_secret.use_vault_provider

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ resource "nomad_job" "nomad_job_postgres" {
     datacenters             = jsonencode(var.nomad_datacenters)
     namespace               = var.nomad_namespace
     service_tags            = jsonencode(var.service_tags)
+    update_health_check     = var.update_health_check
     image                   = var.container_image
     entrypoints             = jsonencode(var.container_entrypoints)
     command                 = var.container_command

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,9 @@ resource "nomad_job" "nomad_job_postgres" {
     namespace               = var.nomad_namespace
     consul_tags             = jsonencode(var.consul_tags)
     image                   = var.container_image
+    entrypoints             = jsonencode(var.container_entrypoints)
+    command                 = var.container_command
+    command_args            = jsonencode(var.container_command_args)
     port                    = var.container_port
     username                = var.admin_user
     password                = var.admin_password

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "nomad_job" "nomad_job_postgres" {
     memory_proxy            = var.resource_proxy.memory
     datacenters             = jsonencode(var.nomad_datacenters)
     namespace               = var.nomad_namespace
-    consul_tags             = jsonencode(var.consul_tags)
+    service_tags            = jsonencode(var.service_tags)
     image                   = var.container_image
     entrypoints             = jsonencode(var.container_entrypoints)
     command                 = var.container_command

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ resource "nomad_job" "nomad_job_postgres" {
     memory_proxy            = var.resource_proxy.memory
     datacenters             = local.datacenters
     namespace               = var.nomad_namespace
-    consul_tags             = join(",", var.consul_tags)
+    consul_tags             = jsonencode(var.consul_tags)
     image                   = var.container_image
     port                    = var.container_port
     username                = var.admin_user

--- a/main.tf
+++ b/main.tf
@@ -33,8 +33,9 @@ resource "nomad_job" "nomad_job_postgres" {
     vault_kv_field_password = var.vault_secret.vault_kv_field_password
     database                = var.database
     nomad_host_volume       = var.nomad_host_volume
+    nomad_csi_volume        = var.nomad_csi_volume
+    nomad_csi_volume_extra  = var.nomad_csi_volume_extra
     volume_destination      = var.volume_destination
-    use_host_volume         = var.use_host_volume
     use_canary              = var.use_canary
     use_connect             = var.use_connect
     memory                  = var.memory

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,7 @@ resource "nomad_job" "nomad_job_postgres" {
     memory                  = var.memory
     cpu                     = var.cpu
     envs                    = local.postgres_env_vars
+    pg_isready_path         = var.pg_isready_path
   })
   detach = false
 }

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ locals {
 resource "nomad_job" "nomad_job_postgres" {
   jobspec = templatefile("${path.module}/conf/nomad/postgres.hcl", {
     service_name            = var.service_name
+    service_provider        = var.service_provider 
     cpu_proxy               = var.resource_proxy.cpu
     memory_proxy            = var.resource_proxy.memory
     datacenters             = jsonencode(var.nomad_datacenters)

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,9 @@ resource "nomad_job" "nomad_job_postgres" {
     vault_kv_field_username = var.vault_secret.vault_kv_field_username
     vault_kv_field_password = var.vault_secret.vault_kv_field_password
     database                = var.database
+    nomad_network_mode      = var.nomad_network_mode
+    nomad_docker_network_mode = var.nomad_docker_network_mode
+    nomad_host_network      = var.nomad_host_network
     nomad_host_volume       = var.nomad_host_volume
     nomad_csi_volume        = var.nomad_csi_volume
     nomad_csi_volume_extra  = var.nomad_csi_volume_extra

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,26 +1,26 @@
 output "service_name" {
   description = "Postgres service name"
-  value       = data.template_file.template_nomad_job_postgres.vars.service_name
+  value       = var.service_name
 }
 
 output "username" {
   description = "Postgres username"
-  value       = data.template_file.template_nomad_job_postgres.vars.username
-  sensitive = true
+  value       = var.admin_user
+  sensitive   = true
 }
 
 output "password" {
   description = "Postgres password"
-  value       = data.template_file.template_nomad_job_postgres.vars.password
-  sensitive = true
+  value       = var.admin_password
+  sensitive   = true
 }
 
 output "database_name" {
   description = "Postgres database name"
-  value       = data.template_file.template_nomad_job_postgres.vars.database
+  value       = var.database
 }
 
 output "port" {
   description = "Postgres port"
-  value       = data.template_file.template_nomad_job_postgres.vars.port
+  value       = var.container_port
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,13 +4,13 @@ output "service_name" {
 }
 
 output "username" {
-  description = "Postgres username"
+  description = "Postgres username (if not using Vault)"
   value       = var.admin_user
   sensitive   = true
 }
 
 output "password" {
-  description = "Postgres password"
+  description = "Postgres password (if not using Vault)"
   value       = var.admin_password
   sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,12 @@ variable "nomad_namespace" {
   default     = "default"
 }
 
+variable "nomad_node" {
+  type        = string
+  description = "Nomad node to constrain with node.unique.name"
+  default     = ""
+}
+
 variable "nomad_host_volume" {
   type        = string
   description = "Nomad Host Volume"

--- a/variables.tf
+++ b/variables.tf
@@ -30,27 +30,27 @@ variable "nomad_csi_volume_extra" {
 }
 
 variable "nomad_job_extra" {
-  type = string
+  type        = string
   description = "Extra config to inject in Nomad's job config stanza"
-  default = ""
+  default     = ""
 }
 
 variable "nomad_group_extra" {
-  type = string
+  type        = string
   description = "Extra config to inject in Nomad's group config stanza"
-  default = ""
+  default     = ""
 }
 
 variable "nomad_task_extra" {
-  type = string
+  type        = string
   description = "Extra config to inject in Nomad's task config stanza"
-  default = ""
+  default     = ""
 }
 
 variable "nomad_docker_config_extra" {
-  type = string
+  type        = string
   description = "Extra config to inject in Nomad's docker/config stanza"
-  default = ""
+  default     = ""
 }
 
 # Consul
@@ -193,7 +193,7 @@ variable "cpu" {
 }
 
 variable "pg_isready_path" {
-  type = string
+  type        = string
   description = "Path to pg_isready script for health checks"
-  default = "/usr/local/bin/pg_isready"
+  default     = "/usr/local/bin/pg_isready"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,24 @@ variable "container_image" {
   default     = "postgres:12-alpine"
 }
 
+variable "container_entrypoints" {
+  type        = list(string)
+  description = "Docker driver entrypoint array"
+  default     = []
+}
+
+variable "container_command" {
+  type        = string
+  description = "Docker driver command string"
+  default     = ""
+}
+
+variable "container_command_args" {
+  type        = list(string)
+  description = "Docker driver command args array"
+  default     = []
+}
+
 variable "container_port" {
   type        = number
   description = "Postgres port"

--- a/variables.tf
+++ b/variables.tf
@@ -71,10 +71,10 @@ variable "nomad_docker_config_extra" {
   default     = ""
 }
 
-variable "consul_tags" {
+variable "service_tags" {
   type        = list(string)
   default     = []
-  description = "List of one or more tags to announce in Consul, for service discovery purposes"
+  description = "List of one or more tags to announce in Consul / Nomad SD, for service discovery purposes"
 }
 
 # Postgres

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,12 @@ variable "nomad_docker_config_extra" {
   default     = ""
 }
 
+variable "update_health_check" {
+  type        = string
+  description = "Value for update.health_check"
+  default     = "checks"
+}
+
 variable "service_tags" {
   type        = list(string)
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -17,9 +17,9 @@ variable "nomad_host_volume" {
 
 # Consul
 variable "consul_tags" {
-    type = list(string)
-    default = [""]
-    description = "List of one or more tags to announce in Consul, for service discovery purposes"
+  type        = list(string)
+  default     = [""]
+  description = "List of one or more tags to announce in Consul, for service discovery purposes"
 }
 
 # Postgres
@@ -49,13 +49,13 @@ variable "admin_user" {
 
 variable "resource_proxy" {
   type = object({
-    cpu     = number,
-    memory  = number
+    cpu    = number,
+    memory = number
   })
   description = "Postgres proxy resources"
   default = {
-    cpu         = 200
-    memory      = 128
+    cpu    = 200
+    memory = 128
   }
   validation {
     condition     = var.resource_proxy.cpu >= 200 && var.resource_proxy.memory >= 128
@@ -97,6 +97,12 @@ variable "use_host_volume" {
 variable "use_canary" {
   type        = bool
   description = "Switch to use canary deployment for Postgres"
+  default     = true
+}
+
+variable "use_connect" {
+  type        = bool
+  description = "Use Consul Connect"
   default     = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -159,3 +159,9 @@ variable "cpu" {
   description = "CPU allocation for Postgres"
   default     = 350
 }
+
+variable "pg_isready_path" {
+  type = string
+  description = "Path to pg_isready script for health checks"
+  default = "/usr/local/bin/pg_isready"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,12 @@ variable "consul_tags" {
 }
 
 # Postgres
+variable "service_provider" {
+  type        = string
+  description = "Service Provider for service stanza"
+  default     = "consul"
+}
+
 variable "service_name" {
   type        = string
   description = "Postgres service name"

--- a/variables.tf
+++ b/variables.tf
@@ -4,15 +4,41 @@ variable "nomad_datacenters" {
   description = "Nomad data centers"
   default     = ["*"]
 }
+
 variable "nomad_namespace" {
   type        = string
   description = "[Enterprise] Nomad namespace"
   default     = "default"
 }
+
 variable "nomad_host_volume" {
   type        = string
   description = "Nomad Host Volume"
   default     = "persistence"
+}
+
+variable "nomad_job_extra" {
+  type = string
+  description = "Extra config to inject in Nomad's job config stanza"
+  default = ""
+}
+
+variable "nomad_group_extra" {
+  type = string
+  description = "Extra config to inject in Nomad's group config stanza"
+  default = ""
+}
+
+variable "nomad_task_extra" {
+  type = string
+  description = "Extra config to inject in Nomad's task config stanza"
+  default = ""
+}
+
+variable "nomad_docker_config_extra" {
+  type = string
+  description = "Extra config to inject in Nomad's docker/config stanza"
+  default = ""
 }
 
 # Consul

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,7 @@
 variable "nomad_datacenters" {
   type        = list(string)
   description = "Nomad data centers"
-  default     = ["dc1"]
+  default     = ["*"]
 }
 variable "nomad_namespace" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,19 @@ variable "nomad_namespace" {
 variable "nomad_host_volume" {
   type        = string
   description = "Nomad Host Volume"
-  default     = "persistence"
+  default     = ""
+}
+
+variable "nomad_csi_volume" {
+  type        = string
+  description = "Nomad CSI Volume"
+  default     = ""
+}
+
+variable "nomad_csi_volume_extra" {
+  type        = string
+  description = "Nomad CSI Volume Extra Config"
+  default     = ""
 }
 
 variable "nomad_job_extra" {
@@ -136,12 +148,6 @@ variable "volume_destination" {
   type        = string
   description = "Postgres volume destination"
   default     = "/var/lib/postgresql/data"
-}
-
-variable "use_host_volume" {
-  type        = bool
-  description = "Switch for nomad jobs to use host volume feature"
-  default     = false
 }
 
 variable "use_canary" {

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,12 @@ variable "container_port" {
   default     = 5432
 }
 
+variable "use_static_port" {
+  type        = bool
+  description = "Switch to make container_port static"
+  default     = false
+}
+
 variable "admin_user" {
   type        = string
   description = "Postgres admin user"

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "nomad_host_volume" {
 # Consul
 variable "consul_tags" {
   type        = list(string)
-  default     = [""]
+  default     = []
   description = "List of one or more tags to announce in Consul, for service discovery purposes"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -172,7 +172,7 @@ variable "vault_secret" {
   })
   description = "Set of properties to be able to fetch secret from vault"
   default = {
-    use_vault_provider      = true
+    use_vault_provider      = false
     vault_kv_policy_name    = "kv-secret"
     vault_kv_path           = "secret/data/postgres"
     vault_kv_field_username = "username"

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,24 @@ variable "nomad_host_volume" {
   default     = ""
 }
 
+variable "nomad_host_network" {
+  type        = string
+  description = "Nomad Host Network"
+  default     = ""
+}
+
+variable "nomad_network_mode" {
+  type        = string
+  description = "Nomad Network Mode"
+  default     = ""
+}
+
+variable "nomad_docker_network_mode" {
+  type        = string
+  description = "Nomad Docker Network Mode"
+  default     = ""
+}
+
 variable "nomad_csi_volume" {
   type        = string
   description = "Nomad CSI Volume"
@@ -53,7 +71,6 @@ variable "nomad_docker_config_extra" {
   default     = ""
 }
 
-# Consul
 variable "consul_tags" {
   type        = list(string)
   default     = []

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     nomad = {
       source  = "hashicorp/nomad"
-      version = "~> 1.4.9"
+      version = "~> 2.0.0"
     }
   }
   required_version = ">= 1.0"

--- a/versions.tf
+++ b/versions.tf
@@ -4,10 +4,6 @@ terraform {
       source  = "hashicorp/nomad"
       version = "~> 1.4.9"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.1.2"
-    }
   }
   required_version = ">= 0.13"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 1.4.9"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0"
 }


### PR DESCRIPTION
I've been using this module to stand up TimescaleDB on Nomad.   It's been super helpful!

But the current code is outdated -- it doesn't work out-of-the-box with modern Terraform (> 1.0 or maybe even >0.13).  There were also some templating bugs with some of the array variables that I fixed (mostly by using `jsonencode`). 

I also added customization points that I needed (no Connect, static ports, customize the launch), or otherwise were simple and made sense to add.

## What was added/changed/fixed?
I summarized the changes in the CHANGELOG and labeled it `0.5.0`:
```
### Changed
- Updated to work with Terraform >1.0
- Fixed `consul_tags` rendering of multiple tags
- Fixed `nomad_datacenters` rendering of multiple datacenters
- `nomad_datacenters` now defaults to the Nomad default of `["*"]`
- Port assignments are now done via the `network` stanza instead of `service` stanza
- Less extraneous whitespace in the generated Nomad job file

### Added
- Added `container_entrypoints`, `container_command`, and `container_command_args` to customize container launch
- Added `use_static_port` to make the `container_port` be a static port
- Added `use_connect` to make Consul Connect optional, default to `true` for backwards compatibility
```

## Checklist (after created PR)
- [ ] Added reviewers
- [ ] Added assignee(s)
- [ ] Added label(s)
- [ ] Added to project
- [ ] Added to milestone